### PR TITLE
Clean Redirect headers

### DIFF
--- a/ckanext/s3filestore/views/resource.py
+++ b/ckanext/s3filestore/views/resource.py
@@ -82,7 +82,7 @@ def resource_download(package_type, id, resource_id, filename=None):
             redir.headers.pop('Authorization', None)
             # remove Origin header because it causes problems with CORS on S3
             redir.headers.pop('Origin', None)
-            return redirect(url)
+            return redir
 
         except ClientError as ex:
             if ex.response['Error']['Code'] in ['NoSuchKey', '404']:

--- a/ckanext/s3filestore/views/resource.py
+++ b/ckanext/s3filestore/views/resource.py
@@ -74,6 +74,14 @@ def resource_download(package_type, id, resource_id, filename=None):
                         'attachment; filename=' + filename,
                 }
                 url = upload.get_signed_url_to_key(key_path, params)
+
+            redir = redirect(url)
+            # remove Authorization header from redirect
+            # so that it doesn't get passed to S3
+            # (which doesn't like it)
+            redir.headers.pop('Authorization', None)
+            # remove Origin header because it causes problems with CORS on S3
+            redir.headers.pop('Origin', None)
             return redirect(url)
 
         except ClientError as ex:


### PR DESCRIPTION
We have a user failing to download from JS with the CKAN API token as `Authorization` header.

This PR remove unused headers from the second redirect request to `S3` endpoint.
It look like the `Authorization` headers is problematic for `S3` and the `Origin` header [is set to `null` ](https://advancedweb.hu/how-to-solve-cors-problems-when-redirecting-to-s3-signed-urls/)

![image](https://user-images.githubusercontent.com/3237309/217057399-61d719b9-254d-4e6c-b631-4ce07ce7a916.png)
